### PR TITLE
MacOS Compatibility

### DIFF
--- a/renderlab/render_frame.py
+++ b/renderlab/render_frame.py
@@ -42,7 +42,7 @@ class RenderFrame(gym.Wrapper):
     def _start(self):
         self.cliptime = time.time()
         self.path = f'{self.directory}/{self.cliptime}.mp4'
-        fourcc = cv2.VideoWriter_fourcc(*'MP4V')
+        fourcc = cv2.VideoWriter_fourcc(*'mp4v')
         self._writer = cv2.VideoWriter(self.path, fourcc, self.fps, self.size)
 
     def _write(self):


### PR DESCRIPTION
Replaced 'MP4V' with 'mp4v' to suppress warning:
`OpenCV: FFMPEG: tag 0x5634504d/'MP4V' is not supported with codec id 12`